### PR TITLE
fix(confirmDialog): force background colour on delete button ('Clear project' dialog)

### DIFF
--- a/client/src/components/editor/dialogs/ConfirmDialog.vue
+++ b/client/src/components/editor/dialogs/ConfirmDialog.vue
@@ -81,6 +81,6 @@ export default {
 }
 
 .confirm-dialog__delete-btn {
-  background-color: #ea493f;
+  background-color: #ea493f !important;
 }
 </style>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

**Description**
> Force background colour of the delete button (from 'Clear project' dialog), to keep the provided CSS rule over all others. Added `!important` rule to the existing button class.

**Related Issue**
> fixes(#22)

**Motivation and Context**
> As explained in #22, the lack of accent colour in this button, involves a lost of context over the action triggered. 

**How Has This Been Tested?**
> Used chrome devtools to confirm that the styles weren't overwritten by any other underlying CSS rule.

**Screenshots**
<img width="371" alt="screen shot 2018-05-06 at 8 52 48 pm" src="https://user-images.githubusercontent.com/5973189/39671610-7b28b218-516f-11e8-956a-d42371f7e7cf.png">

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
