### PR TITLE
fix: preview link on editor header

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.18.0",
   "description": "vuegg UI",
   "author": "alxpez",
-  "license" : "MIT",
+  "license": "MIT",
   "private": false,
   "scripts": {
     "dev": "node build/dev-server.js",

--- a/client/src/components/editor/header/ActionBar.vue
+++ b/client/src/components/editor/header/ActionBar.vue
@@ -16,11 +16,11 @@
       </svgicon>
     </button>
 
-    <button v-tooltip="'Preview'" class="action-btn">
-      <router-link to="preview">
+    <router-link :to="{name: 'preview'}">
+      <button v-tooltip="'Preview'" class="action-btn">
         <svgicon icon="system/actions/preview" width="24" height="24" color="#2b6a73"></svgicon>
-      </router-link>
-    </button>
+      </button>
+    </router-link>
 
     <div class="separator"></div>
 

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.5",
   "description": "serves vuegg-client sources && generates vuejs projects",
   "author": "alxpez",
-  "license" : "MIT",
+  "license": "MIT",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
**Description**
> Fix the preview link to be able to navigate to "preview" section.

**Motivation and Context**
> This fix is necessary for the proper functioning of vuegg on firefox browser (unsure if it affects any other). Currently the preview button on the editor header, does not trigger navigation of firefox due to the wrapping of the `router-link` element inside a `button`.

**How Has This Been Tested?**
> - Tested on firefox browser, it does navigate to preview properly

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
