### PR TITLE
fix: position of new elements when added on a zoomed editor

### DIFF
--- a/client/src/components/editor/common/ZoomMenu.vue
+++ b/client/src/components/editor/common/ZoomMenu.vue
@@ -21,31 +21,19 @@
 import '@/assets/icons/system/editor/zoom_in'
 import '@/assets/icons/system/editor/zoom_out'
 
+const MAX_ZOOM = 2.5
+const MIN_ZOOM = 0.5
+
 export default {
   name: 'zoom-menu',
-  data: function () {
-    return {
-      zoom: 1,
-      max: 2.5,
-      min: 0.5
-    }
-  },
+  props: ['zoom'],
   computed: {
-    canZoomIn () { return this.zoom < this.max },
-    canZoomOut () { return this.zoom > this.min }
+    canZoomIn () { return this.zoom < MAX_ZOOM },
+    canZoomOut () { return this.zoom > MIN_ZOOM }
   },
   methods: {
-    zoomIn () {
-      this.zoom = Math.round((this.zoom + 0.1) * 10) / 10
-      this.emitChanges()
-    },
-
-    zoomOut () {
-      this.zoom = Math.round((this.zoom - 0.1) * 10) / 10
-      this.emitChanges()
-    },
-
-    emitChanges () { this.$emit('zoomChange', this.zoom) }
+    zoomIn () { this.$emit('zoomChange', Math.round((this.zoom + 0.1) * 10) / 10) },
+    zoomOut () { this.$emit('zoomChange', Math.round((this.zoom - 0.1) * 10) / 10) }
   }
 }
 </script>

--- a/client/src/components/editor/main/Stage.vue
+++ b/client/src/components/editor/main/Stage.vue
@@ -123,6 +123,10 @@ export default {
       let top = e.pageY + mainContainer.scrollTop - mainContainer.offsetTop - this.$el.offsetTop - (height / 2)
       let left = e.pageX + mainContainer.scrollLeft - mainContainer.offsetLeft - this.$el.offsetLeft - (width / 2)
 
+      // Correct drop positions based on the editorZoom
+      top = Math.round(top / this.zoom)
+      left = Math.round(left / this.zoom)
+
       const fixedElement = fixElementToParentBounds({top, left, height, width}, this.page)
       element = {...element, ...fixedElement}
 

--- a/client/src/components/editor/main/index.vue
+++ b/client/src/components/editor/main/index.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="mainegg">
     <stage v-if="selectedPage" :page="selectedPage" :zoom="zoom"></stage>
-    <zoom-menu @zoomChange="zoomHandler" class="zoom-menu"></zoom-menu>
+    <zoom-menu @zoomChange="zoomHandler" :zoom="zoom" class="zoom-menu"></zoom-menu>
   </div>
 </template>
 
 
 <script>
 import { mapState, mapGetters, mapMutations } from 'vuex'
-import { _changeActivePage, _rebaseActivePage, getPageIndexById } from '@/store/types'
+import { _changeActivePage, _rebaseActivePage, _updateEditorZoom, getPageIndexById } from '@/store/types'
 
 import ZoomMenu from '@/components/editor/common/ZoomMenu'
 import Stage from './Stage'
@@ -16,18 +16,14 @@ import Stage from './Stage'
 export default {
   name: 'mainegg',
   components: { Stage, ZoomMenu },
-  data: function () {
-    return {
-      zoom: 1
-    }
-  },
   created: function () {
     this.selectFallbackPage(this.selectedPage)
   },
   computed: {
     ...mapState({
       selectedPage: state => state.app.selectedPage,
-      pages: state => state ? state.project.pages : []
+      pages: state => state ? state.project.pages : [],
+      zoom: state => state.app.editorZoom
     }),
     ...mapGetters([getPageIndexById])
   },
@@ -47,10 +43,10 @@ export default {
     },
 
     zoomHandler (zoomValue) {
-      this.zoom = zoomValue
+      this._updateEditorZoom(zoomValue)
     },
 
-    ...mapMutations([_changeActivePage, _rebaseActivePage])
+    ...mapMutations([_changeActivePage, _rebaseActivePage, _updateEditorZoom])
   }
 }
 </script>

--- a/client/src/factories/stateFactory.js
+++ b/client/src/factories/stateFactory.js
@@ -14,7 +14,8 @@ function newState (project) {
         isOpen: false
       },
       selectedPage: null,
-      selectedElements: []
+      selectedElements: [],
+      editorZoom: 1
     },
     oauth: {
       isAuthorized: false,

--- a/client/src/store/mutations/appMut.js
+++ b/client/src/store/mutations/appMut.js
@@ -53,6 +53,15 @@ const internalAppMutations = {
  */
   [types._toggleCanRedo]: function (state, canRedo) {
     state.app.canRedo = canRedo
+  },
+
+  /**
+   * Updates the valie of editorZoom property with the value passed in the payload
+   *
+   * @param {number} currentZoom : Number with the current zoom value
+   */
+  [types._updateEditorZoom]: function (state, currentZoom) {
+    state.app.editorZoom = currentZoom
   }
 }
 

--- a/client/src/store/types.js
+++ b/client/src/store/types.js
@@ -68,8 +68,9 @@ export const _toggleHasChanges = '_toggleHasChanges'
 export const _toggleIsSyncing = '_toggleIsSyncing'
 export const _toggleCanRedo = '_toggleCanRedo'
 export const _toggleCanUndo = '_toggleCanUndo'
-
 export const _togglePageDialog = '_togglePageDialog'
+export const _updateEditorZoom = '_updateEditorZoom'
+
 export const _changeActivePage = '_changeActivePage'
 export const _rebaseActivePage = '_rebaseActivePage'
 
@@ -146,8 +147,9 @@ const types = {
   _toggleIsSyncing,
   _toggleCanRedo,
   _toggleCanUndo,
-
   _togglePageDialog,
+  _updateEditorZoom,
+
   _changeActivePage,
   _rebaseActivePage,
 


### PR DESCRIPTION
**Description**
> - Refactor the zoom functionality to include the editorZoom state in the vuex store

> - Fix dropping position of elements on editorZoomed. When having any sort of zoom on the editor and adding an new element to stage, the position takes the zoom value in consideration

**Motivation and Context**
> A minor bug was identify, when the editor is zoomed (in or out) and an element gets added to the stage, where it gets incorrectly positioned.

**How Has This Been Tested?**
> Manually

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
