### PR TITLE
Corrected typo mistake in client component editor MenuToggle.vue

### DIFF
--- a/client/src/components/editor/common/MenuToggle.vue
+++ b/client/src/components/editor/common/MenuToggle.vue
@@ -19,8 +19,8 @@ export default {
   name: 'menu-toggle',
   props: {
     menuHeader: { type: String, default: '' },
-    startClosed: { type: Boolean, dafault: false },
-    hidden: { type: Boolean, dafault: false }
+    startClosed: { type: Boolean, default: false },
+    hidden: { type: Boolean, default: false }
   },
   data: function () {
     return {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

**Description**
There was a typo mistake in a component, it was written "dafault" instead of "default". This may affect the functionality of the program

**How Has This Been Tested?**
This issue was found by running a static analysis tool, DeepScan that pointed out this typo. 

**Types of changes**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project - just 2 words changed
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
